### PR TITLE
Implement retry loop for websocket acknowledgements

### DIFF
--- a/config.go
+++ b/config.go
@@ -106,6 +106,7 @@ func loadConfig() {
 		} else if len(az.AS) == 0 {
 			log.Fatalf("Appservice %s doesn't have the HS token set", az.ID)
 		}
+		az.acks = make(map[string]chan struct{})
 		cfg.byASToken[az.AS] = az
 		cfg.byHSToken[az.HS] = az
 	}


### PR DESCRIPTION
## Summary
- wait for websocket acknowledgement before completing appservice transaction
- retry sending data until ack is received
- preserve pending ack state until connection closes

## Testing
- `go build ./...` *(fails: proxy.golang.org Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68667a76170c832089e6e062c9e6daa8